### PR TITLE
Update 4-infinite-compession/problem.md

### DIFF
--- a/problems/4-infinite-compression/problem.md
+++ b/problems/4-infinite-compression/problem.md
@@ -3,16 +3,18 @@
 YAS BOSS! That's how you do it! 
 
 Let's move on.
-## What’s the Deal with Infinite Compression?
-Imagine compressing your data over and over until it’s reduced to its absolute minimum size. While true infinite compression is more of a thought experiment, in this challenge, you’ll get a taste of it by working with Content-Addressed Archives (CARs) and Directed Acyclic Graphs (DAGs).
- 
-The DAG is packed into a CAR 🚗 - beep beep. CAR is kinda like a `tar` file but for DAGs. It's a useful container format for transferring content addressed data over HTTP.
+## What’s the Deal with Content Addressing?
+So, here’s the scoop: when you upload data to Storacha (previously web3.storage), it gets transformed into a **Directed Acyclic Graph (DAG)**. Each piece of your data becomes a node, and each node gets a unique identifier called a **Content Identifier (CID)**. This whole DAG is then packed into a Content-Addressed Archive (CAR)—think of it like a digital suitcase for your data, ready to travel the web.
 
-**Here’s how it works:** when you upload a file, it gets split into smaller pieces called CAR shards. Each of these shards gets a unique identifier called a CID (Content Identifier). When you’ve uploaded all the shards, they come together to form a DAG—a super-organized structure that ties everything up neatly with a root CID.
+## How It Works:
+When you upload a file, it’s broken down into smaller pieces called **CAR shards**. Each shard gets its own CID, making it easy to identify and retrieve.
+After all the shards are uploaded, they come together to form the full DAG, with a root CID that ties everything together.
+ 
+Here’s the best part: If the system already has the data you’re trying to upload, it’ll tell you so. No need to send the data again! It’s like magic—data management on autopilot! 🚗✨
 
 ## Your Task:
 1. Start by creating a new file, like ex5.mjs.
-2. Upload Content: You’ll upload a file—maybe another cat meme—just like you did before. But this time, the file gets split into multiple shards.
+2. Upload Content: You’ll upload a file — maybe another cat meme — just like you did before. But this time, the file gets split into multiple shards.
 ```js
 const client = await Client.create()
 const files = await filesFromPaths(['./awesome-cat-meme.jpg'])
@@ -30,13 +32,17 @@ console.log(root.toString())
 
 ## Why It’s Awesome:
 **Efficiency:** You’re not just uploading data—you’re breaking it down and managing it in a super-efficient way.
+
 **Organization:** The DAG structure helps keep your data neatly organized, and the CIDs act as a digital map to navigate it all.
 
-## Next Steps:
-**Run the Code:** Try running your code to see the CIDs of each shard and the final DAG root.
-**Explore Further:** Think about how this structure could be used in larger projects or how you might expand on it.
+** No Redundant Uploads:** Thanks to content addressing, if the data already exists, you don’t need to send it again—saving time and bandwidth.
 
-Now, it’s your turn to dive into the world of infinite compression! Good luck, and have fun compressing! 🚀
+## Next Steps:
+**1. Run the Code:** Try running your code to see the CIDs of each shard and the final DAG root.
+
+**2. Explore Further:** Think about how this structure could be used in larger projects or how you might expand on it.
+
+Now it’s time to dive into the world of content-addressed data! Have fun compressing and organizing your data, and may your CAR files travel far and wide! 🚗💨
 
 ─────────────────────────────────────────────────────────────────────────────
 * To print these instructions again, run: `$ADVENTURE_NAME print`


### PR DESCRIPTION
Addressing previous feedback
[problems/4-infinite-compression/problem.md](https://github.com/storacha-network/learnyouw3up/pull/21/files/1962b78750fc9d67b25805c4291673f722adcb2d#diff-cd61e0714a71d0a0764f3e0725f78696f90481bba94c115b96095228bcfcd2fd)

In web3.storage, we content address CARs as well! So we generate a hash for the CAR and invoke a `store/add` capability, passing the CAR CID as parameters to the invocation. The service will reply with a signed URL - a place to put the CAR that will only accept data that hashes to the CID of the CAR.

**BUT** if we know the CAR you want to send has already been stored then we'll send back a flag to say that you don't need to send it! Hey presto, infinite compression! Joking aside, isn't content addressing awesome?!
Member
@[alanshaw](https://github.com/alanshaw) alanshaw [yesterday](https://github.com/storacha-network/learnyouw3up/pull/21#discussion_r1717001054)
I feel like we've lost information here.

"Infinite compression" is not real, but is an attempt to put a name to this advantage:

We content address the data, and because we do that, the service can determine if it already has the data without actually sending it. If the service has the data, you do not need to send it - i.e. you have "infinite compression" because you did not send anything!